### PR TITLE
Schema support for Entities and Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ policy_set = CedarPolicy::PolicySet.new(policy)
 
 > Currently, the single policy is not supported.
 
+### Schema
+
+Optionally, define a schema in Cedar Schema Language:
+
+```ruby
+schema = CedarPolicy::Schema.new(
+  <<~SCHEMA
+    entity User, Admin, Image;
+
+    action view appliesTo {
+        principal: [User],
+        resource: [Image]
+    };
+
+    action delete appliesTo {
+        principal: [Admin],
+        resource: [Image]
+    };
+  SCHEMA
+)
+```
+
+You can check that your schema parsed as expected with the `#principals`, `#resources`, `#action_groups`, and `#actions` methods on `Schema`.
+
 ### Request
 
 Prepare the Entity's ID via `EntityUid` or an object with `#to_hash` method which returns a hash with `:type` and `:id` keys.
@@ -76,6 +100,14 @@ entities = CedarPolicy::Entities.new([
     }
 ])
 ```
+
+You can optionally pass a CedarPolicy::Schema to `Entities.new`, which will allow Cedar to evaluate action groups and validate the structure of your entities:
+
+```ruby
+entities = CedarPolicy::Entities.new(entities_array, schema: schema)
+```
+
+> Entities will not be validated until they are used for authorization.
 
 ### Authorizer
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Create a `Request` object with the principal, action, resource, and context.
 request = CedarPolicy::Request.new(principal, action, resource, ctx)
 ```
 
+You can pass a CedarPolicy::Schema via the optional `schema:` option when creating the request to validate that the request conforms to the Cedar schema. If the request does not validate, a `CedarPolicy::RequestValidationError` exception will be raised.
+
+```ruby
+# NOTE: this will raise an exception if given an invalid principal + action + resource combination!
+request = CedarPolicy::Request.new(principal, action, resource, ctx, schema: schema)
+```
+
 ### Entities
 
 Define the entities with related this request. It should be an array of `Entity` objects which have `#to_hash` method returns a hash with `:uid`,`:attrs`, and `:parents` keys.

--- a/ext/cedar_policy/src/entities.rs
+++ b/ext/cedar_policy/src/entities.rs
@@ -1,12 +1,12 @@
 use cedar_policy::ffi::JsonValueWithNoDuplicateKeys;
-use cedar_policy::Entities;
+use cedar_policy::{Entities, Schema};
 use magnus::{
     value::{Lazy, ReprValue},
     Error, Module, RClass, Ruby, TryConvert, Value,
 };
 use serde_magnus::deserialize;
 
-use crate::CEDAR_POLICY;
+use crate::{CEDAR_POLICY, schema::RSchema};
 
 static ENTITIES: Lazy<RClass> = Lazy::new(|ruby| {
     ruby.get_inner(&CEDAR_POLICY)
@@ -25,13 +25,25 @@ impl From<EntitiesWrapper> for Entities {
 impl TryConvert for EntitiesWrapper {
     fn try_convert(value: Value) -> Result<Self, Error> {
         let handle = Ruby::get_with(value);
+        let schema = match value.respond_to("schema", false) {
+            Ok(true) => {
+                let schema: Value = value.funcall_public("schema", ())?;
+                if schema.is_nil() {
+                    None
+                } else {
+                    let r_schema = <&RSchema>::try_convert(schema)?;
+                    Some(Schema::from(r_schema))
+                }
+            },
+            _ => None,
+        };
         match value.respond_to("to_ary", false) {
             Ok(true) => {
                 let value: Value = value.funcall_public("to_ary", ())?;
                 let value: JsonValueWithNoDuplicateKeys = deserialize(value)?;
+                let entities = Entities::from_json_value(value.into(), schema.as_ref());
                 Ok(Self(
-                    Entities::from_json_value(value.into(), None)
-                        .map_err(|e| Error::new(handle.exception_arg_error(), e.to_string()))?,
+                    entities.map_err(|e| Error::new(handle.exception_arg_error(), e.to_string()))?,
                 ))
             }
             Err(e) => Err(Error::new(handle.exception_arg_error(), e.to_string())),

--- a/ext/cedar_policy/src/error.rs
+++ b/ext/cedar_policy/src/error.rs
@@ -21,6 +21,12 @@ pub static AUTHORIZATION_ERROR: Lazy<ExceptionClass> = Lazy::new(|ruby| {
         .unwrap()
 });
 
+pub static REQUEST_VALIDATION_ERROR: Lazy<ExceptionClass> = Lazy::new(|ruby| {
+    ruby.get_inner(&CEDAR_POLICY)
+        .define_error("RequestValidationError", ruby.exception_standard_error())
+        .unwrap()
+});
+
 #[magnus::wrap(class = "CedarPolicy::AuthorizationError")]
 pub struct RAuthorizationError(AuthorizationError);
 
@@ -39,6 +45,7 @@ impl From<AuthorizationError> for RAuthorizationError {
 pub fn init(ruby: &Ruby) -> Result<(), Error> {
     Lazy::force(&PARSE_ERROR, ruby);
     Lazy::force(&ENTITIES_ERROR, ruby);
+    Lazy::force(&REQUEST_VALIDATION_ERROR, ruby);
 
     ruby.get_inner(&AUTHORIZATION_ERROR);
 

--- a/ext/cedar_policy/src/lib.rs
+++ b/ext/cedar_policy/src/lib.rs
@@ -8,6 +8,7 @@ mod entities;
 mod entity_uid;
 mod error;
 mod policy_set;
+mod schema;
 mod request;
 mod response;
 
@@ -26,6 +27,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     authorizer::init(ruby, &module)?;
     request::init(ruby, &module)?;
     response::init(ruby)?;
+    schema::init(ruby, &module)?;
     policy_set::init(ruby, &module)?;
 
     Ok(())

--- a/ext/cedar_policy/src/schema.rs
+++ b/ext/cedar_policy/src/schema.rs
@@ -1,0 +1,72 @@
+use std::{collections::HashSet, str::FromStr};
+
+use cedar_policy::{CedarSchemaError, Schema};
+use magnus::{function, method, Error, Module, Object, RArray, RModule, RString, Ruby};
+
+use crate::error::PARSE_ERROR;
+
+#[magnus::wrap(class = "CedarPolicy::Schema")]
+pub struct RSchema(Schema);
+
+impl RSchema {
+    fn new(ruby: &Ruby, schema: RString) -> Result<Self, Error> {
+        if schema.is_empty() {
+            Err(Error::new(
+                ruby.get_inner(&PARSE_ERROR),
+                "you must supply schema contents",
+            ))
+        } else {
+            Self::from_str(&schema.to_string()?)
+                .map_err(|e| Error::new(ruby.get_inner(&PARSE_ERROR), e.to_string()))
+        }
+    }
+
+    pub fn principals(&self) -> RArray {
+        let principals = self.0.principals().collect::<HashSet<_>>();
+        RArray::from_iter(principals.iter().map(|principal| principal.to_string()))
+    }
+
+    pub fn resources(&self) -> RArray {
+        let resources = self.0.resources().collect::<HashSet<_>>();
+        RArray::from_iter(resources.iter().map(|resource| resource.to_string()))
+    }
+
+    pub fn action_groups(&self) -> RArray {
+        RArray::from_iter(self.0.action_groups().map(|group| group.to_string()))
+    }
+
+    pub fn actions(&self) -> RArray {
+        RArray::from_iter(self.0.actions().map(|action| action.to_string()))
+    }
+}
+
+impl From<RSchema> for Schema {
+    fn from(schema: RSchema) -> Self {
+        schema.0
+    }
+}
+
+impl From<&RSchema> for Schema {
+    fn from(schema: &RSchema) -> Self {
+        schema.0.clone()
+    }
+}
+
+impl FromStr for RSchema {
+    type Err = CedarSchemaError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Schema::from_str(s)?))
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("Schema", ruby.class_object())?;
+    class.define_singleton_method("new", function!(RSchema::new, 1))?;
+    class.define_method("principals", method!(RSchema::principals, 0))?;
+    class.define_method("resources", method!(RSchema::resources, 0))?;
+    class.define_method("action_groups", method!(RSchema::action_groups, 0))?;
+    class.define_method("actions", method!(RSchema::actions, 0))?;
+
+    Ok(())
+}

--- a/lib/cedar_policy/entities.rb
+++ b/lib/cedar_policy/entities.rb
@@ -5,12 +5,20 @@ module CedarPolicy
   class Entities
     include Enumerable
 
-    def initialize(entities = [])
+    # Include schema in Entities to enable Cedar to evaluate Action groups.
+    attr_accessor :schema
+
+    def initialize(entities = [], schema: nil)
       @entities = Set.new(entities.map do |entity|
         next entity if entity.is_a?(Entity)
 
         Entity.new(*entity.values_at(:uid, :attrs, :parents))
       end)
+
+      if schema
+        schema = Schema.new(schema) unless schema.is_a?(Schema)
+        self.schema = schema
+      end
     end
 
     def each(&block)

--- a/spec/cedar_policy/authorizer_spec.rb
+++ b/spec/cedar_policy/authorizer_spec.rb
@@ -172,5 +172,152 @@ RSpec.describe CedarPolicy::Request do
         is_expected.to have_attributes(diagnostics: have_attributes(errors: be_none))
       }
     end
+
+    context "when there is schema attached to entities" do
+      subject { authorizer.authorize(request, policy_set, entities) }
+
+      let(:policy) do
+        <<~POLICY
+          permit(
+            principal is User,
+            action == Action::"View",
+            resource
+          );
+
+          permit(
+            principal is User,
+            action == Action::"Edit",
+            resource
+          ) when { resource.owner == principal };
+
+          permit(
+            principal,
+            action in Action::"AdminActions",
+            resource
+          ) when { principal has isAdmin && principal.isAdmin };
+        POLICY
+      end
+
+      let(:schema) do
+        <<~SCHEMA
+          entity User {
+            isAdmin?: Bool
+          };
+
+          entity Image {
+            owner: User
+          };
+
+          action AdminActions;
+
+          action View in [AdminActions] appliesTo {
+              principal: [User],
+              resource: [Image]
+          };
+
+          action Edit in [AdminActions] appliesTo {
+              principal: [User],
+              resource: [Image]
+          };
+
+          action Delete in [AdminActions] appliesTo {
+              principal: [User],
+              resource: [Image]
+          };
+        SCHEMA
+      end
+
+      let(:entities) do
+        CedarPolicy::Entities.new(entities_data, schema: schema)
+      end
+
+      describe "User can View image" do
+        let(:action) { CedarPolicy::EntityUid.new("Action", "View") }
+        let(:entities_data) {
+          [
+            {uid: {type: "User", id: 1}, attrs: {}, parents: []},
+            {uid: {type: "Image", id: 1}, attrs: {owner: {type: "User", id: " 1"}}, parents: []}
+          ]
+        }
+
+        it { is_expected.to(have_attributes(decision: CedarPolicy::Decision::ALLOW)) }
+      end
+
+      describe "Owner can Edit image" do
+        let(:action) { CedarPolicy::EntityUid.new("Action", "Edit") }
+        let(:entities_data) {
+          [
+            {uid: {type: "User", id: "1"}, attrs: {}, parents: []},
+            {uid: {type: "Image", id: "1"}, attrs: {owner: {type: "User", id: "1"}}, parents: []}
+          ]
+        }
+
+        it { is_expected.to(have_attributes(decision: CedarPolicy::Decision::ALLOW)) }
+      end
+
+      describe "Non-Owner cannot Edit image" do
+        let(:principal) { CedarPolicy::EntityUid.new("User", "3") }
+        let(:action) { CedarPolicy::EntityUid.new("Action", "Edit") }
+        let(:entities_data) {
+          [
+            {uid: {type: "User", id: "1"}, attrs: {}, parents: []},
+            {uid: {type: "User", id: "3"}, attrs: {}, parents: []},
+            {uid: {type: "Image", id: "1"}, attrs: {owner: {type: "User", id: " 1"}}, parents: []}
+          ]
+        }
+
+        it { is_expected.to(have_attributes(decision: CedarPolicy::Decision::DENY)) }
+      end
+
+      describe "Admin can Delete image" do
+        let(:principal) { CedarPolicy::EntityUid.new("User", "2") }
+        let(:action) { CedarPolicy::EntityUid.new("Action", "Delete") }
+        let(:entities_data) {
+          [
+            {uid: {type: "User", id: "1"}, attrs: {}, parents: []},
+            {uid: {type: "User", id: "2"}, attrs: {isAdmin: true}, parents: []},
+            {uid: {type: "Image", id: "1"}, attrs: {owner: {type: "User", id: " 1"}}, parents: []}
+          ]
+        }
+
+        it { is_expected.to(have_attributes(decision: CedarPolicy::Decision::ALLOW)) }
+      end
+
+      describe "entity with superfluous attribute" do
+        let(:entities_data) {
+          [
+            {uid: {type: "User", id: "1"}, attrs: {extra: "0xfeedc0de"}, parents: []},
+            {uid: {type: "User", id: "2"}, attrs: {isAdmin: true}, parents: []},
+            {uid: {type: "Image", id: "1"}, attrs: {owner: {type: "User", id: " 1"}}, parents: []}
+          ]
+        }
+
+        it { expect { authorizer.authorize(request, policy_set, entities) }.to(raise_error(ArgumentError)) }
+      end
+
+      describe "entity with missing attribute" do
+        let(:entities_data) {
+          [
+            {uid: {type: "User", id: "1"}, attrs: {}, parents: []},
+            {uid: {type: "User", id: "2"}, attrs: {isAdmin: true}, parents: []},
+            {uid: {type: "Image", id: "1"}, attrs: {}, parents: []}
+          ]
+        }
+
+        it { expect { authorizer.authorize(request, policy_set, entities) }.to(raise_error(ArgumentError)) }
+      end
+
+      describe "entity with incorrectly-typed attribute" do
+        let(:entities_data) {
+          [
+            {uid: {type: "User", id: "1"}, attrs: {}, parents: []},
+            {uid: {type: "User", id: "2"}, attrs: {isAdmin: "0xfeedc0de"}, parents: []},
+            {uid: {type: "Image", id: "1"}, attrs: {owner: {type: "User", id: " 1"}}, parents: []}
+          ]
+        }
+
+        it { expect { authorizer.authorize(request, policy_set, entities) }.to(raise_error(ArgumentError)) }
+      end
+    end
   end
 end

--- a/spec/cedar_policy/entities_spec.rb
+++ b/spec/cedar_policy/entities_spec.rb
@@ -37,4 +37,36 @@ RSpec.describe CedarPolicy::Entities do
       it { is_expected.to be_one }
     end
   end
+
+  describe "with schema" do
+    let(:schema) do
+      CedarPolicy::Schema.new(
+        <<~SCHEMA
+          entity User {
+            isAdmin?: Bool
+          };
+
+          entity Image {
+            owner: User
+          };
+
+          action View  appliesTo {
+              principal: [User],
+              resource: [Image]
+          };
+        SCHEMA
+      )
+    end
+
+    let(:user) { {uid: {type: "User", id: 1}, attrs: {}, parents: []} }
+    let(:admin) { {uid: {type: "User", id: 2}, attrs: {isAdmin: true}, parents: []} }
+    let(:image) { {uid: {type: "Image", id: 1}, attrs: {owner: {type: "User", id: 1}}, parents: []} }
+
+    subject(:entities) do
+      CedarPolicy::Entities.new([user, admin, image], schema: schema)
+    end
+
+    it { is_expected.to(satisfy { |entities| entities.to_ary.size == 3 }) }
+    it { is_expected.to(have_attributes(schema: schema)) }
+  end
 end

--- a/spec/cedar_policy/schema_spec.rb
+++ b/spec/cedar_policy/schema_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe CedarPolicy::Schema do
+  describe "invalid schema raises parse error" do
+    subject(:schema) { CedarPolicy::Schema.new("not a valid cedar schema") }
+
+    it { expect { schema }.to(raise_error(CedarPolicy::ParseError)) }
+  end
+
+  context("with a valid schema") do
+    let(:schema) do
+      CedarPolicy::Schema.new(
+        <<~SCHEMA
+          entity User, Admin, Image;
+
+          action AdminActions;
+
+          action View appliesTo {
+              principal: [User],
+              resource: [Image]
+          };
+
+          action Delete in [AdminActions] appliesTo {
+              principal: [Admin],
+              resource: [Image]
+          };
+        SCHEMA
+      )
+    end
+
+    describe "#actions returns all defined actions and action groups" do
+      subject(:actions) { schema.actions }
+      it { is_expected.to(contain_exactly(*%w[Action::"AdminActions" Action::"Delete" Action::"View"])) }
+    end
+
+    describe "#action_groups returns all defined action groups" do
+      subject(:action_groups) { schema.action_groups }
+      it { is_expected.to(contain_exactly(*%w[Action::"AdminActions"])) }
+    end
+
+    describe "#principals returns all entities mentioned as principals" do
+      subject(:principals) { schema.principals }
+
+      it { is_expected.to(contain_exactly(*%w[User Admin])) }
+    end
+
+    describe "#resources returns all entities mentioned as resources" do
+      subject(:resources) { schema.resources }
+
+      it { is_expected.to(contain_exactly(*%w[Image])) }
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses #7 by adding schema support in two places:

1. when parsing entities from JSON into Cedar Entities
2. when creating Cedar Request objects

Because entities are only converted from `EntitiesWrapper` to actual `Cedar Entities` when they are sent into the `authorize` or `is_authorized` methods, this validation doesn't happen right away when you instantiate `CedarPolicy::Entities`.

However, Cedar Requests **are** created immediately when creating `CedarPolicy::Request` objects, so the validation **does** happen right away when you instantiate `CedarPolicy::Request`. It would be nice if these two bits of validation were consistent with each other, but I was trying to avoid invasive changes.

Note: I am new to programming in Rust, so there are likely some bits of code that are not very rust-like; I am happy to learn more and make adjustments!