### PR TITLE
chore: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Ruby
+permissions:
+  contents: read
 
 on:
   push:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,7 @@
-export default { extends: ['@commitlint/config-conventional'] };
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [0, 'never', 100],
+    'body-max-line-length': [0, 'never', 100],
+  }
+};


### PR DESCRIPTION
Potential fix for [https://github.com/elct9620/cedar-policy-rb/security/code-scanning/2](https://github.com/elct9620/cedar-policy-rb/security/code-scanning/2)

To fix the issue, we need to explicitly define the permissions for the `GITHUB_TOKEN` in the workflow. Since the workflow primarily involves checking out the repository, setting up environments, and running tests, it likely only requires `contents: read` permissions. We will add a `permissions` block at the root level of the workflow to apply these permissions to all jobs. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow permissions to explicitly grant read access to repository contents.
	- Adjusted commit message guidelines to remove maximum line length restrictions for headers and bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->