### PR TITLE
Add Ruby 4.0 to cross-compile matrix

### DIFF
--- a/.cross_rubies
+++ b/.cross_rubies
@@ -33,3 +33,10 @@
 3.4:x86_64-darwin
 3.4:x86_64-linux-gnu
 3.4:x86_64-linux-musl
+4.0:aarch64-linux-gnu
+4.0:aarch64-linux-musl
+4.0:arm64-darwin
+4.0:x64-mingw-ucrt
+4.0:x86_64-darwin
+4.0:x86_64-linux-gnu
+4.0:x86_64-linux-musl


### PR DESCRIPTION
## Summary

- Adds `4.0:<platform>` entries to `.cross_rubies` for all 7 tracked platforms (aarch64-linux-gnu, aarch64-linux-musl, arm64-darwin, x64-mingw-ucrt, x86_64-darwin, x86_64-linux-gnu, x86_64-linux-musl).

## Why

`rake-compiler`'s `RbSys::ExtensionTask` derives each precompiled gem's `required_ruby_version` upper bound from the highest entry in `.cross_rubies` via `String#succ` (e.g. `"3.4".succ` => `"3.5"`). With 3.4 as the current max, published `cedar_policy` gems declare `>= 3.0, < 3.5.dev`, which excludes Ruby 4.0 and causes Ruby-version-compatibility tooling to flag `cedar_policy` as incompatible with Ruby 4.0, even though `main.yml`'s own CI matrix already tests and passes against Ruby 4.0.

Bumping the max `.cross_rubies` entry to `4.0` widens the generated bound to `< 4.1.dev`, which correctly covers Ruby 4.0.x.
